### PR TITLE
Update .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,5 @@ linters:
     - staticcheck
     - tenv
     - unconvert
-    - unparam
     - unused
     - vet


### PR DESCRIPTION
This linter is causing churn in the code for no benefit. The `unused` linter already reports on unused stuff.