### PR TITLE
Reconcile state w/ manually deleted rule

### DIFF
--- a/internal/provider/common_test.go
+++ b/internal/provider/common_test.go
@@ -5,6 +5,10 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-provider-grafana-adaptive-metrics/internal/client"
 )
 
 func CheckAccTestsEnabled(t *testing.T) {
@@ -30,4 +34,21 @@ func RandString(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+func AggregationRulesForAccTest(t *testing.T) *AggregationRules {
+	t.Helper()
+
+	apiURL := os.Getenv("GRAFANA_AM_API_URL")
+	apiKey := os.Getenv("GRAFANA_AM_API_KEY")
+
+	c, err := client.New(apiURL, &client.Config{
+		APIKey: apiKey,
+	})
+	require.NoError(t, err)
+
+	aggRules := NewAggregationRules(c)
+	require.NoError(t, aggRules.Init())
+
+	return aggRules
 }

--- a/internal/provider/rule_resource.go
+++ b/internal/provider/rule_resource.go
@@ -143,7 +143,8 @@ func (r *ruleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	rule, err := r.rules.Read(state.Metric.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to read aggregation rule", err.Error())
+		resp.Diagnostics.AddWarning("Unable to read aggregation rule", err.Error())
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
https://github.com/grafana/terraform-provider-grafana-adaptive-metrics/issues/13

When a rule is deleted by an external source, this TF provider will no emit a warning but offer to recreate the rule instead of error-ing out.