### PR TITLE
Add optional create or update for rules resource

### DIFF
--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -38,6 +38,7 @@ resource "grafana-adaptive-metrics_rule" "prometheus_request_duration_seconds_su
 - `aggregation_delay` (String) The delay until aggregation is performed.
 - `aggregation_interval` (String) The interval at which to generate the aggregated series.
 - `aggregations` (List of String) The array of aggregation types to calculate for this metric.
+- `auto_import` (Boolean) When set to true, the rule will be automatically imported if it is not already in Terraform state.
 - `drop` (Boolean) Set to true to skip both ingestion and aggregation and drop the metric entirely.
 - `drop_labels` (List of String) The array of labels that will be aggregated.
 - `keep_labels` (List of String) The array of labels to keep; labels not in this array will be aggregated.

--- a/internal/model/rule.go
+++ b/internal/model/rule.go
@@ -53,6 +53,8 @@ type RuleTF struct {
 	AggregationInterval types.String `tfsdk:"aggregation_interval"`
 	AggregationDelay    types.String `tfsdk:"aggregation_delay"`
 
+	AutoImport types.Bool `tfsdk:"auto_import"`
+
 	LastUpdated types.String `tfsdk:"-"`
 }
 


### PR DESCRIPTION
https://github.com/grafana/terraform-provider-grafana-adaptive-metrics/issues/40

Instead of error-ing out when creating an aggregation rule that already exists, update it and import it into Terraform state.