### PR TITLE
Add segment to recommendations

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -108,10 +108,28 @@ func TestAggregationRecommendations(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	actual, err := c.AggregationRecommendations(false, nil)
+	actual, err := c.AggregationRecommendations("", false, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, recsPayload, actual)
+}
+
+func TestAggregationSegmentedRecommendations(t *testing.T) {
+	s := newMockServer(t)
+	defer s.close()
+
+	s.addExpected("GET", "/aggregations/recommendations",
+		withRespBody(minifiedVerboseJson),
+		withParams(url.Values{"verbose": []string{"true"}, "segment": []string{"segment-id"}}),
+	)
+
+	c, err := New(s.server.URL, &Config{})
+	require.NoError(t, err)
+
+	actual, err := c.AggregationRecommendations("segment-id", true, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, verboseRecsPayload, actual)
 }
 
 func TestAggregationVerboseRecommendations(t *testing.T) {
@@ -126,7 +144,7 @@ func TestAggregationVerboseRecommendations(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	actual, err := c.AggregationRecommendations(true, nil)
+	actual, err := c.AggregationRecommendations("", true, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, verboseRecsPayload, actual)
@@ -144,7 +162,7 @@ func TestAggregationRecommendationsWithAction(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	actual, err := c.AggregationRecommendations(false, []string{"add", "update"})
+	actual, err := c.AggregationRecommendations("", false, []string{"add", "update"})
 	require.NoError(t, err)
 
 	require.Equal(t, recsPayload, actual)

--- a/internal/client/recommendations.go
+++ b/internal/client/recommendations.go
@@ -12,9 +12,12 @@ const (
 	recommendationsConfigEndpoint = "/aggregations/recommendations/config"
 )
 
-func (c *Client) AggregationRecommendations(verbose bool, action []string) ([]model.AggregationRecommendation, error) {
+func (c *Client) AggregationRecommendations(segmentID string, verbose bool, action []string) ([]model.AggregationRecommendation, error) {
 	var recs []model.AggregationRecommendation
 	params := url.Values{}
+	if segmentID != "" {
+		params.Add("segment", segmentID)
+	}
 	if verbose {
 		params.Add("verbose", "true")
 	}

--- a/internal/model/recommendation.go
+++ b/internal/model/recommendation.go
@@ -43,6 +43,7 @@ func (r *AggregationRecommendation) ToTF() AggregationRecommendationTF {
 type AggregationRecommendationListTF struct {
 	Verbose         types.Bool                    `tfsdk:"verbose"`
 	Action          []types.String                `tfsdk:"action"`
+	Segment         types.String                  `tfsdk:"segment"`
 	Recommendations []AggregationRecommendationTF `tfsdk:"recommendations"`
 }
 

--- a/internal/provider/recommendations_datasource.go
+++ b/internal/provider/recommendations_datasource.go
@@ -49,6 +49,10 @@ func (r *recommendationDatasource) Metadata(_ context.Context, req datasource.Me
 func (r *recommendationDatasource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"segment": schema.StringAttribute{
+				Optional:    true,
+				Description: "The name of the segment to get recommendations for.",
+			},
 			"verbose": schema.BoolAttribute{
 				Optional:    true,
 				Description: "If true, the response will include additional information about the recommendation, such as the number of rules, queries, and dashboards that use the metric.",
@@ -147,7 +151,7 @@ func (r *recommendationDatasource) Read(ctx context.Context, req datasource.Read
 	var state model.AggregationRecommendationListTF
 	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
 
-	recs, err := r.client.AggregationRecommendations(state.IsVerbose(), state.GetActionIn())
+	recs, err := r.client.AggregationRecommendations(state.Segment.ValueString(), state.IsVerbose(), state.GetActionIn())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read aggregation rule", err.Error())
 		return


### PR DESCRIPTION
Tested with this against my dev stack:

```

locals {
  jobs = {
    kubelet  = "integrations/kubernetes/kubelet",
    cadvisor = "integrations/kubernetes/cadvisor",
    ksm      = "integrations/kubernetes/kube-state-metrics",
    nodeexp  = "integrations/kubernetes/node-exporter",
  }
}

resource "grafana-adaptive-metrics_segment" "all" {
  for_each = local.jobs
  name     = "${each.value} job"
  selector = "{job=\"${each.value}\"}"
}


data "grafana-adaptive-metrics_recommendations" "default" {
  verbose = true
}

output "metrics_in_default_recs" {
  value = sort([for rec in data.grafana-adaptive-metrics_recommendations.default.recommendations : rec.metric])
}

data "grafana-adaptive-metrics_recommendations" "segmented" {
  for_each = local.jobs
  segment  = grafana-adaptive-metrics_segment.all[each.key].id
  verbose  = true
}

output "metrics_in_segment_recs" {
  value = {
    for name in keys(local.jobs) : name =>
    (data.grafana-adaptive-metrics_recommendations.segmented[name].recommendations == null ? []
    : [for rec in data.grafana-adaptive-metrics_recommendations.segmented[name].recommendations : rec.metric])
  }
}
```

