### PR TITLE
Add segment support to rules 

### DIFF
--- a/docs/data-sources/recommendations.md
+++ b/docs/data-sources/recommendations.md
@@ -27,6 +27,7 @@ output "recs" {
 ### Optional
 
 - `action` (List of String) Limit the types of recommended actions to list. Valid recommended actions are 'add', 'remove', 'keep', and 'update'. Defaults to listing all actions.
+- `segment` (String) The name of the segment to get recommendations for.
 - `verbose` (Boolean) If true, the response will include additional information about the recommendation, such as the number of rules, queries, and dashboards that use the metric.
 
 ### Read-Only

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -43,3 +43,4 @@ resource "grafana-adaptive-metrics_rule" "prometheus_request_duration_seconds_su
 - `drop_labels` (List of String) The array of labels that will be aggregated.
 - `keep_labels` (List of String) The array of labels to keep; labels not in this array will be aggregated.
 - `match_type` (String) Specifies how the metric field matches to incoming metric names. Can be 'prefix', 'suffix', or 'exact', defaults to 'exact'.
+- `segment` (String) The name of the segment to aggregate metrics for.

--- a/internal/client/aggregations.go
+++ b/internal/client/aggregations.go
@@ -13,7 +13,7 @@ const (
 	aggregationRuleEndpoint  = "/aggregations/rule/%s"
 )
 
-func (c *Client) AggregationRules() ([]model.AggregationRule, string, error) {
+func (c *Client) AggregationRules(segmentID string) ([]model.AggregationRule, string, error) {
 	var rules []model.AggregationRule
 	header, err := c.requestWithHeaders("GET", aggregationRulesEndpoint, nil, nil, nil, &rules)
 	if err != nil {
@@ -28,7 +28,7 @@ func (c *Client) AggregationRules() ([]model.AggregationRule, string, error) {
 	return rules, etag, err
 }
 
-func (c *Client) UpdateAggregationRules(rules []model.AggregationRule, etag string) (string, error) {
+func (c *Client) UpdateAggregationRules(segmentID string, rules []model.AggregationRule, etag string) (string, error) {
 	body, err := json.Marshal(rules)
 	if err != nil {
 		return "", err
@@ -50,7 +50,7 @@ func (c *Client) UpdateAggregationRules(rules []model.AggregationRule, etag stri
 	return newEtag, nil
 }
 
-func (c *Client) CreateAggregationRule(rule model.AggregationRule, etag string) (string, error) {
+func (c *Client) CreateAggregationRule(segmentID string, rule model.AggregationRule, etag string) (string, error) {
 	body, err := json.Marshal(rule)
 	if err != nil {
 		return "", err
@@ -74,7 +74,7 @@ func (c *Client) CreateAggregationRule(rule model.AggregationRule, etag string) 
 	return newEtag, nil
 }
 
-func (c *Client) ReadAggregationRule(metric string) (model.AggregationRule, string, error) {
+func (c *Client) ReadAggregationRule(segmentID string, metric string) (model.AggregationRule, string, error) {
 	rule := model.AggregationRule{}
 	endpoint := fmt.Sprintf(aggregationRuleEndpoint, metric)
 
@@ -91,7 +91,7 @@ func (c *Client) ReadAggregationRule(metric string) (model.AggregationRule, stri
 	return rule, newEtag, nil
 }
 
-func (c *Client) UpdateAggregationRule(rule model.AggregationRule, etag string) (string, error) {
+func (c *Client) UpdateAggregationRule(segmentID string, rule model.AggregationRule, etag string) (string, error) {
 	body, err := json.Marshal(rule)
 	if err != nil {
 		return "", err
@@ -115,7 +115,7 @@ func (c *Client) UpdateAggregationRule(rule model.AggregationRule, etag string) 
 	return newEtag, nil
 }
 
-func (c *Client) DeleteAggregationRule(metric, etag string) (string, error) {
+func (c *Client) DeleteAggregationRule(segmentID string, metric, etag string) (string, error) {
 	reqHeader := make(http.Header)
 	reqHeader.Add("If-Match", etag)
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -219,7 +219,7 @@ func TestAggregationRules(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	actualRules, actualEtag, err := c.AggregationRules()
+	actualRules, actualEtag, err := c.AggregationRules("")
 	require.NoError(t, err)
 
 	require.Equal(t, etag, actualEtag)
@@ -247,7 +247,7 @@ func TestUpdateAggregationRules(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	newEtag, err := c.UpdateAggregationRules(rulesPayload, etag)
+	newEtag, err := c.UpdateAggregationRules("", rulesPayload, etag)
 	require.NoError(t, err)
 
 	require.Equal(t, "\"updated-fake-etag\"", newEtag)
@@ -273,7 +273,7 @@ func TestCreateAggregationRule(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	newEtag, err := c.CreateAggregationRule(model.AggregationRule{Metric: "test_metric", Drop: true}, etag)
+	newEtag, err := c.CreateAggregationRule("", model.AggregationRule{Metric: "test_metric", Drop: true}, etag)
 	require.NoError(t, err)
 
 	require.Equal(t, "\"updated-fake-etag\"", newEtag)
@@ -295,7 +295,7 @@ func TestReadAggregationRule(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	actual, newEtag, err := c.ReadAggregationRule("test_metric")
+	actual, newEtag, err := c.ReadAggregationRule("", "test_metric")
 	require.NoError(t, err)
 
 	require.Equal(t, etag, newEtag)
@@ -322,7 +322,7 @@ func TestUpdateAggregationRule(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	newEtag, err := c.UpdateAggregationRule(model.AggregationRule{Metric: "test_metric", Drop: true}, etag)
+	newEtag, err := c.UpdateAggregationRule("", model.AggregationRule{Metric: "test_metric", Drop: true}, etag)
 	require.NoError(t, err)
 
 	require.Equal(t, "\"updated-fake-etag\"", newEtag)
@@ -347,7 +347,7 @@ func TestDeleteAggregationRule(t *testing.T) {
 	c, err := New(s.server.URL, &Config{})
 	require.NoError(t, err)
 
-	newEtag, err := c.DeleteAggregationRule("test_metric", etag)
+	newEtag, err := c.DeleteAggregationRule("", "test_metric", etag)
 	require.NoError(t, err)
 
 	require.Equal(t, "\"updated-fake-etag\"", newEtag)

--- a/internal/model/rule.go
+++ b/internal/model/rule.go
@@ -8,6 +8,12 @@ import (
 
 const managedByTF = "terraform"
 
+type SegmentedRuleSet struct {
+	Etag    string            `json:"etag"`
+	Segment Segment           `json:"segment"`
+	Rules   []AggregationRule `json:"rules"`
+}
+
 type AggregationRule struct {
 	Metric    string `json:"metric"`
 	MatchType string `json:"match_type,omitempty"`

--- a/internal/model/rule.go
+++ b/internal/model/rule.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -41,6 +43,7 @@ func (r AggregationRule) ToTF() RuleTF {
 }
 
 type RuleTF struct {
+	Segment   types.String `tfsdk:"segment"`
 	Metric    types.String `tfsdk:"metric"`
 	MatchType types.String `tfsdk:"match_type"`
 
@@ -56,6 +59,14 @@ type RuleTF struct {
 	AutoImport types.Bool `tfsdk:"auto_import"`
 
 	LastUpdated types.String `tfsdk:"-"`
+}
+
+func (r RuleTF) TFIdentifier() string {
+	if r.Segment.IsNull() {
+		return r.Metric.ValueString()
+	}
+
+	return fmt.Sprintf("%s/%s", r.Segment.ValueString(), r.Metric.ValueString())
 }
 
 func (r RuleTF) ToAPIReq() AggregationRule {

--- a/internal/provider/common_test.go
+++ b/internal/provider/common_test.go
@@ -48,7 +48,7 @@ func AggregationRulesForAccTest(t *testing.T) *AggregationRules {
 	})
 	require.NoError(t, err)
 
-	aggRules := NewAggregationRules(c)
+	aggRules := NewAggregationRules(c, "")
 	require.NoError(t, aggRules.Init())
 
 	return aggRules

--- a/internal/provider/common_test.go
+++ b/internal/provider/common_test.go
@@ -48,7 +48,7 @@ func AggregationRulesForAccTest(t *testing.T) *AggregationRules {
 	})
 	require.NoError(t, err)
 
-	aggRules := NewAggregationRules(c, "")
+	aggRules := NewAggregationRules(c)
 	require.NoError(t, aggRules.Init())
 
 	return aggRules

--- a/internal/provider/rule_resource.go
+++ b/internal/provider/rule_resource.go
@@ -189,7 +189,7 @@ func (r *ruleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	if plan.Metric.ValueString() != state.Metric.ValueString() {
+	if plan.TFIdentifier() != state.TFIdentifier() {
 		err := r.rules.Delete(state.ToAPIReq())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to replace aggregation rule", err.Error())

--- a/internal/provider/rule_resource.go
+++ b/internal/provider/rule_resource.go
@@ -52,6 +52,10 @@ func (r *ruleResource) Metadata(_ context.Context, req resource.MetadataRequest,
 func (r *ruleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"segment": schema.StringAttribute{
+				Optional:    true,
+				Description: "The name of the segment to aggregate metrics for.",
+			},
 			"metric": schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the metric to be aggregated.",
@@ -123,17 +127,17 @@ func (r *ruleResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	if plan.AutoImport.ValueBool() {
-		_, err := r.rules.Read(plan.Metric.ValueString())
+		_, err := r.rules.Read(plan.Segment.ValueString(), plan.Metric.ValueString())
 		if err != nil {
 			// There is no existing rule for this metric; create it.
-			err := r.rules.Create(plan.ToAPIReq())
+			err := r.rules.Create(plan.Segment.ValueString(), plan.ToAPIReq())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to create aggregation rule", err.Error())
 				return
 			}
 		} else {
 			// There is an existing rule for this metric; update it.
-			err := r.rules.Update(plan.ToAPIReq())
+			err := r.rules.Update(plan.Segment.ValueString(), plan.ToAPIReq())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to update aggregation rule", err.Error())
 				return
@@ -142,7 +146,7 @@ func (r *ruleResource) Create(ctx context.Context, req resource.CreateRequest, r
 			resp.Diagnostics.AddWarning("Existing aggregation rule for metric found", "The existing rule has been updated and imported into Terraform state; no aggregation rule has been created.")
 		}
 	} else {
-		err := r.rules.Create(plan.ToAPIReq())
+		err := r.rules.Create(plan.Segment.ValueString(), plan.ToAPIReq())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to create aggregation rule", err.Error())
 			return
@@ -160,7 +164,7 @@ func (r *ruleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	rule, err := r.rules.Read(state.Metric.ValueString())
+	rule, err := r.rules.Read(state.Segment.ValueString(), state.Metric.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddWarning("Unable to read aggregation rule", err.Error())
 		resp.State.RemoveResource(ctx)
@@ -168,6 +172,10 @@ func (r *ruleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	tf := rule.ToTF()
+
+	// Segment tells us where to put the rule later, but isn't actually a part
+	// of the rule, so we set it separately.
+	tf.Segment = state.Segment
 
 	// AutoImport is a meta field used by this Terraform provider; the API never returns
 	// a value for it so we keep it updated separately.
@@ -190,19 +198,19 @@ func (r *ruleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	if plan.TFIdentifier() != state.TFIdentifier() {
-		err := r.rules.Delete(state.ToAPIReq())
+		err := r.rules.Delete(state.Segment.ValueString(), state.ToAPIReq())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to replace aggregation rule", err.Error())
 			return
 		}
 
-		err = r.rules.Create(plan.ToAPIReq())
+		err = r.rules.Create(plan.Segment.ValueString(), plan.ToAPIReq())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to replace aggregation rule", err.Error())
 			return
 		}
 	} else {
-		err := r.rules.Update(plan.ToAPIReq())
+		err := r.rules.Update(plan.Segment.ValueString(), plan.ToAPIReq())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to update aggregation rule", err.Error())
 			return
@@ -220,7 +228,7 @@ func (r *ruleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	err := r.rules.Delete(state.ToAPIReq())
+	err := r.rules.Delete(state.Segment.ValueString(), state.ToAPIReq())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to delete aggregation rule", err.Error())
 	}

--- a/internal/provider/rule_resource_test.go
+++ b/internal/provider/rule_resource_test.go
@@ -17,7 +17,7 @@ func TestAccRuleResource(t *testing.T) {
 	metricName := fmt.Sprintf("test_tf_metric_%s", RandString(6))
 	t.Cleanup(func() {
 		aggRules := AggregationRulesForAccTest(t)
-		_ = aggRules.Delete(model.AggregationRule{Metric: metricName})
+		_ = aggRules.Delete("", model.AggregationRule{Metric: metricName})
 	})
 
 	resource.Test(t, resource.TestCase{
@@ -27,7 +27,7 @@ func TestAccRuleResource(t *testing.T) {
 			{
 				PreConfig: func() {
 					aggRules := AggregationRulesForAccTest(t)
-					require.NoError(t, aggRules.Create(model.AggregationRule{Metric: metricName, DropLabels: []string{"foobar"}, Aggregations: []string{"sum"}}))
+					require.NoError(t, aggRules.Create("", model.AggregationRule{Metric: metricName, DropLabels: []string{"foobar"}, Aggregations: []string{"sum"}}))
 				},
 				Config: providerConfig + fmt.Sprintf(`
 resource "grafana-adaptive-metrics_rule" "test" {
@@ -62,7 +62,7 @@ resource "grafana-adaptive-metrics_rule" "test" {
 			{
 				PreConfig: func() {
 					aggRules := AggregationRulesForAccTest(t)
-					require.NoError(t, aggRules.Delete(model.AggregationRule{Metric: metricName}))
+					require.NoError(t, aggRules.Delete("", model.AggregationRule{Metric: metricName}))
 				},
 				Config: providerConfig + fmt.Sprintf(`
 resource "grafana-adaptive-metrics_rule" "test" {
@@ -120,7 +120,7 @@ resource "grafana-adaptive-metrics_rule" "test" {
 			{
 				PreConfig: func() {
 					aggRules := AggregationRulesForAccTest(t)
-					require.NoError(t, aggRules.Delete(model.AggregationRule{Metric: metricName}))
+					require.NoError(t, aggRules.Delete("", model.AggregationRule{Metric: metricName}))
 				},
 				Config: providerConfig + fmt.Sprintf(`
 resource "grafana-adaptive-metrics_rule" "test" {

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -24,7 +24,7 @@ func (r *AggregationRules) Init() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	rules, etag, err := r.client.AggregationRules()
+	rules, etag, err := r.client.AggregationRules(r.segmentID)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func (r *AggregationRules) Create(rule model.AggregationRule) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	etag, err := r.client.CreateAggregationRule(rule, r.etag)
+	etag, err := r.client.CreateAggregationRule(r.segmentID, rule, r.etag)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (r *AggregationRules) Update(rule model.AggregationRule) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	etag, err := r.client.UpdateAggregationRule(rule, r.etag)
+	etag, err := r.client.UpdateAggregationRule(r.segmentID, rule, r.etag)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (r *AggregationRules) Delete(rule model.AggregationRule) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	etag, err := r.client.DeleteAggregationRule(rule.Metric, r.etag)
+	etag, err := r.client.DeleteAggregationRule(r.segmentID, rule.Metric, r.etag)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/hashicorp/terraform-provider-grafana-adaptive-metrics/internal/client"
@@ -12,80 +11,78 @@ type AggregationRules struct {
 	client *client.Client
 	mu     sync.RWMutex
 
-	etag  string
-	rules map[string]model.AggregationRule
+	segmentEtags map[string]string
 }
 
 func NewAggregationRules(c *client.Client) *AggregationRules {
-	return &AggregationRules{client: c, mu: sync.RWMutex{}, rules: make(map[string]model.AggregationRule)}
+	return &AggregationRules{client: c, mu: sync.RWMutex{}}
 }
 
 func (r *AggregationRules) Init() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	rules, etag, err := r.client.AggregationRules(r.segmentID)
+	ruleSets, err := r.client.SegmentedAggregationRules()
 	if err != nil {
 		return err
 	}
 
-	for _, rule := range rules {
-		r.rules[rule.Metric] = rule
+	r.segmentEtags = make(map[string]string, len(ruleSets))
+	for _, ruleSet := range ruleSets {
+		r.segmentEtags[ruleSet.Segment.ID] = ruleSet.Etag
 	}
-	r.etag = etag
+
 	return nil
 }
 
-func (r *AggregationRules) Create(rule model.AggregationRule) error {
+func (r *AggregationRules) Create(segmentID string, rule model.AggregationRule) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	etag, err := r.client.CreateAggregationRule(r.segmentID, rule, r.etag)
+	etag, err := r.client.CreateAggregationRule(segmentID, rule, r.segmentEtags[segmentID])
 	if err != nil {
 		return err
 	}
 
-	r.etag = etag
-	r.rules[rule.Metric] = rule
+	r.segmentEtags[segmentID] = etag
 	return nil
 }
 
-func (r *AggregationRules) Read(metric string) (model.AggregationRule, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+func (r *AggregationRules) Read(segmentID string, metric string) (model.AggregationRule, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	rule, ok := r.rules[metric]
-	if !ok {
-		return model.AggregationRule{}, fmt.Errorf("no rule for %s found", metric)
+	rule, etag, err := r.client.ReadAggregationRule(segmentID, metric)
+	if err != nil {
+		return model.AggregationRule{}, err
 	}
 
+	r.segmentEtags[segmentID] = etag
 	return rule, nil
 }
 
-func (r *AggregationRules) Update(rule model.AggregationRule) error {
+func (r *AggregationRules) Update(segmentID string, rule model.AggregationRule) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	etag, err := r.client.UpdateAggregationRule(r.segmentID, rule, r.etag)
+	etag, err := r.client.UpdateAggregationRule(segmentID, rule, r.segmentEtags[segmentID])
 	if err != nil {
 		return err
 	}
 
-	r.etag = etag
-	r.rules[rule.Metric] = rule
+	r.segmentEtags[segmentID] = etag
 	return nil
 }
 
-func (r *AggregationRules) Delete(rule model.AggregationRule) error {
+func (r *AggregationRules) Delete(segmentID string, rule model.AggregationRule) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	etag, err := r.client.DeleteAggregationRule(r.segmentID, rule.Metric, r.etag)
+	etag, err := r.client.DeleteAggregationRule(segmentID, rule.Metric, r.segmentEtags[segmentID])
 	if err != nil {
 		return err
 	}
 
-	r.etag = etag
-	delete(r.rules, rule.Metric)
+	r.segmentEtags[segmentID] = etag
 	return nil
 }


### PR DESCRIPTION
This PR adds segment support to the rule resource, which also involves managing etags per-segment instead of globally.