### PR TITLE
Fix usage example typo for recommendations_config

### DIFF
--- a/docs/resources/recommendations_config.md
+++ b/docs/resources/recommendations_config.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource "grafana-adaptive-metrics_resource_config" "singleton" {
+resource "grafana-adaptive-metrics_recommendations_config" "singleton" {
   keep_labels = ["namespace"]
 }
 ```

--- a/examples/resources/grafana-adaptive-metrics_recommendations_config/resource.tf
+++ b/examples/resources/grafana-adaptive-metrics_recommendations_config/resource.tf
@@ -1,3 +1,3 @@
-resource "grafana-adaptive-metrics_resource_config" "singleton" {
+resource "grafana-adaptive-metrics_recommendations_config" "singleton" {
   keep_labels = ["namespace"]
 }


### PR DESCRIPTION
Example usage for resource grafana-adaptive-metrics_recommendations_config contained a typo.

Fixes #58