### PR TITLE
[Acceptance Tests] Limit concurrent tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: acceptance-tests
     strategy:
       max-parallel: 1
       matrix:


### PR DESCRIPTION
The acceptance tests depend on a real cloud stack, so we can't run multiple instances in parallel. This PR prevents that so I can avoid re-trying the job over and over again.