### PR TITLE
[Rule Resource] Use planmodifiers to trigger recreate

### DIFF
--- a/internal/model/rule.go
+++ b/internal/model/rule.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -65,14 +63,6 @@ type RuleTF struct {
 	AutoImport types.Bool `tfsdk:"auto_import"`
 
 	LastUpdated types.String `tfsdk:"-"`
-}
-
-func (r RuleTF) TFIdentifier() string {
-	if r.Segment.IsNull() {
-		return r.Metric.ValueString()
-	}
-
-	return fmt.Sprintf("%s/%s", r.Segment.ValueString(), r.Metric.ValueString())
 }
 
 func (r RuleTF) ToAPIReq() AggregationRule {


### PR DESCRIPTION
We had some logic to detect when a metric name or segment changes, because in those cases we need to destroy and recreate a rule. 

It turns out the terraform sdk has a built-in way to express that, so this PR uses it instead.