### PR TITLE
[Segment Resource] UseStateForUnknown modifier on id

### DIFF
--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-provider-grafana-adaptive-metrics/internal/client"
 	"github.com/hashicorp/terraform-provider-grafana-adaptive-metrics/internal/model"
 )
@@ -54,6 +56,9 @@ func (e *segmentResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: privatePreviewWarning + "A ULID that uniquely identifies the segment.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,


### PR DESCRIPTION
While testing internally, I found that the provider wants to recreate a ruleset if the corresponding segment is updated at all. This is not necessary and is actively harmful. It would mean that the rules are unapplied temporarily (even if only for a few seconds).

The root cause is that terraform doesn't know the `id` is constant once created. This PR uses a modifier from the framework to specify that.