### PR TITLE
External delete: handle 404 by removing state

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -157,6 +158,11 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, header
 
 	req.Header.Add("Content-Type", "application/json")
 	return req, err
+}
+
+func IsErrNotFound(err error) bool {
+	var e ErrNotFound
+	return errors.As(err, &e)
 }
 
 type ErrNotFound struct {

--- a/internal/client/segments.go
+++ b/internal/client/segments.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/hashicorp/terraform-provider-grafana-adaptive-metrics/internal/model"
@@ -59,7 +58,9 @@ func (c *Client) ReadSegment(id string) (model.Segment, error) {
 		}
 	}
 
-	return model.Segment{}, fmt.Errorf("segment not found")
+	return model.Segment{}, ErrNotFound{
+		BodyContents: []byte("segment not found"),
+	}
 }
 
 func (c *Client) UpdateSegment(s model.Segment) error {

--- a/internal/provider/exemption_resource.go
+++ b/internal/provider/exemption_resource.go
@@ -134,6 +134,11 @@ func (e *exemptionResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	ex, err := e.client.ReadExemption(state.Segment.ValueString(), state.ID.ValueString())
 	if err != nil {
+		if client.IsErrNotFound(err) {
+			resp.Diagnostics.AddWarning("Exemption not found", err.Error())
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read exemption", err.Error())
 		return
 	}

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -106,6 +106,11 @@ func (e *segmentResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	segment, err := e.client.ReadSegment(state.ID.ValueString())
 	if err != nil {
+		if client.IsErrNotFound(err) {
+			resp.Diagnostics.AddWarning("Segment not found", err.Error())
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read segment", err.Error())
 		return
 	}


### PR DESCRIPTION
Another bug found while testing: if a resource is deleted outside of terraform, we don't handle the 404 properly. This puts terraform in a broken state where you have to use `terraform state rm` to fix it. Instead, we should do this in the resources, that way the resource just appears in the plan as "you need to add this back". 

Basically #25 but for all resources. I also fixed how #25 was implemented, because it didn't actually check for a 404 and instead just removed the state on any error.