### PR TITLE
[Ruleset] Add import support

### DIFF
--- a/docs/resources/ruleset.md
+++ b/docs/resources/ruleset.md
@@ -38,8 +38,7 @@ data "grafana-adaptive-metrics_recommendations" "default" {
 }
 
 resource "grafana-adaptive-metrics_ruleset" "default" {
-  # stable_sort_rules ensures that the rules are always applied in the same order, regardless of the ordering of the recommendations
-  rules = provider::grafana-adaptive-metrics::stable_sort_rules(data.grafana-adaptive-metrics_recommendations.default.recommendations)
+  rules = data.grafana-adaptive-metrics_recommendations.default.recommendations
 }
 ```
 
@@ -70,3 +69,15 @@ Optional:
 - `drop_labels` (List of String) The array of labels that will be aggregated.
 - `keep_labels` (List of String) The array of labels to keep; labels not in this array will be aggregated.
 - `match_type` (String) Specifies how the metric field matches to incoming metric names. Can be 'prefix', 'suffix', or 'exact', defaults to 'exact'.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Import the ruleset from the default segment
+terraform import grafana-adaptive-metrics_ruleset.rules default
+
+# Import the ruleset from a custom segment
+terraform import grafana-adaptive-metrics_ruleset.rules $CUSTOM_SEGMENT_ID
+```

--- a/examples/functions/stable_sort_rules/function.tf
+++ b/examples/functions/stable_sort_rules/function.tf
@@ -1,9 +1,0 @@
-
-# Apply the latest recommendations on each apply
-data "grafana-adaptive-metrics_recommendations" "default" {
-}
-
-resource "grafana-adaptive-metrics_ruleset" "default" {
-  # stable_sort_rules ensures that the rules are always applied in the same order, regardless of the ordering of the recommendations
-  rules = provider::grafana-adaptive-metrics::stable_sort_rules(data.grafana-adaptive-metrics_recommendations.default.recommendations)
-}

--- a/examples/resources/grafana-adaptive-metrics_ruleset/import.sh
+++ b/examples/resources/grafana-adaptive-metrics_ruleset/import.sh
@@ -1,0 +1,6 @@
+
+# Import the ruleset from the default segment
+terraform import grafana-adaptive-metrics_ruleset.rules default
+
+# Import the ruleset from a custom segment
+terraform import grafana-adaptive-metrics_ruleset.rules $CUSTOM_SEGMENT_ID

--- a/examples/resources/grafana-adaptive-metrics_ruleset/resource.tf
+++ b/examples/resources/grafana-adaptive-metrics_ruleset/resource.tf
@@ -24,6 +24,5 @@ data "grafana-adaptive-metrics_recommendations" "default" {
 }
 
 resource "grafana-adaptive-metrics_ruleset" "default" {
-  # stable_sort_rules ensures that the rules are always applied in the same order, regardless of the ordering of the recommendations
-  rules = provider::grafana-adaptive-metrics::stable_sort_rules(data.grafana-adaptive-metrics_recommendations.default.recommendations)
+  rules = data.grafana-adaptive-metrics_recommendations.default.recommendations
 }

--- a/internal/provider/ruleset_resource_test.go
+++ b/internal/provider/ruleset_resource_test.go
@@ -66,6 +66,14 @@ resource "grafana-adaptive-metrics_ruleset" "test" {
 					resource.TestCheckResourceAttr("grafana-adaptive-metrics_ruleset.test", "rules.0.aggregation_delay", ""),
 				),
 			},
+			// ImportState.
+			{
+				ResourceName:                         "grafana-adaptive-metrics_ruleset.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        "default",
+				ImportStateVerifyIdentifierAttribute: "segment",
+			},
 			// Update + Read.
 			{
 				Config: providerConfig + fmt.Sprintf(`

--- a/internal/provider/ruleset_resource_test.go
+++ b/internal/provider/ruleset_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,11 +69,28 @@ resource "grafana-adaptive-metrics_ruleset" "test" {
 			},
 			// ImportState.
 			{
-				ResourceName:                         "grafana-adaptive-metrics_ruleset.test",
-				ImportState:                          true,
-				ImportStateVerify:                    true,
-				ImportStateId:                        "default",
-				ImportStateVerifyIdentifierAttribute: "segment",
+				ResourceName: "grafana-adaptive-metrics_ruleset.test",
+				ImportState:  true,
+				// We can't use ImportStateVerify because ruleset is a singleton, and has no id.
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					if len(is) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(is))
+					}
+
+					ruleset := is[0].Attributes
+					if ruleset["rules.#"] != "1" {
+						return fmt.Errorf("expected 1 rule, got %s", ruleset["rules.#"])
+					}
+					if ruleset["rules.0.metric"] != metricName {
+						return fmt.Errorf("expected metric %s, got %s", metricName, ruleset["rules.0.metric"])
+					}
+					if ruleset["rules.0.drop"] != "true" {
+						return fmt.Errorf("expected drop true, got %s", ruleset["rules.0.drop"])
+					}
+
+					return nil
+				},
+				ImportStateId: "default",
 			},
 			// Update + Read.
 			{


### PR DESCRIPTION
When migrating an existing configuration to terraform, it can be scary to apply a huge number of rules all at once. By supporting import, we can pre-load the current state into terraform. Now when you apply it will show a proper diff, instead of just being one giant "create" operation.