### PR TITLE
Securing Github Actions for Terraform Provider: Grafana Adaptive Metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,12 @@ jobs:
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
-          cache: true
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@main
+          cache: false
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746 # main as of 28/04/2025
         with:
           repo_secrets: |
             GPG_PRIVATE_KEY=release:private-key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746 # main as of 28/04/2025
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             GPG_PRIVATE_KEY=release:private-key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read  # Testing only needs permissions to read the repository contents.
-  id-token: write # Needed to assume roles from Github's OIDC.
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -23,6 +22,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
@@ -38,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
@@ -59,6 +62,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: "go.mod"
@@ -75,6 +80,9 @@ jobs:
     timeout-minutes: 15
     concurrency:
       group: acceptance-tests
+    permissions:
+      contents: read  # Testing only needs permissions to read the repository contents.
+      id-token: write # Needed to assume roles from Github's OIDC.
     strategy:
       max-parallel: 1
       matrix:
@@ -87,6 +95,8 @@ jobs:
           - '1.4.*'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
@@ -95,7 +105,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746 # main as of 28/04/2025
         with:
           repo_secrets: |
             GRAFANA_AM_API_URL=cloud-tests:api-url


### PR DESCRIPTION
Securing GH actions as followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).  Based on `zizmor` recommendations.

<details><summary>before</summary>
<p>

```
❯ zizmor --gh-token=$(gh auth token) grafana/terraform-provider-grafana-adaptive-metrics                                           
 INFO collect_inputs: zizmor: collected 2 inputs from grafana/terraform-provider-grafana-adaptive-metrics
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed .github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/test.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/release.yml:21:9
   |
21 |         - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
   |  _________-
22 | |         with:
23 | |           # Allow goreleaser to access older tag information.
24 | |           fetch-depth: 0
   | |________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/release.yml:29:9
   |
29 |       - uses: grafana/shared-workflows/actions/get-vault-secrets@main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> .github/workflows/release.yml:6:1
   |
 6 | / on:
 7 | |   push:
...  |
11 | | # Releases need permissions to read and write the repository contents.
12 | | # GitHub considers creating releases and uploading assets as writing contents.
   | |______________________________________________________________________________^ generally used when publishing artifacts generated at runtime
13 |   permissions:
...
25 |         - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
26 | /         with:
27 | |           go-version-file: 'go.mod'
28 | |           cache: true
   | |_____________________^ opt-in for caching here
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:25:9
   |
25 |       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:40:9
   |
40 |       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:61:9
   |
61 |       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:89:9
   |
89 |       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/test.yml:16:3
   |
16 |   id-token: write # Needed to assume roles from Github's OIDC.
   |   ^^^^^^^^^^^^^^^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/test.yml:98:9
   |
98 |       - uses: grafana/shared-workflows/actions/get-vault-secrets@main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

11 findings (2 suppressed): 0 unknown, 0 informational, 0 low, 5 medium, 4 high
```

</p>
</details> 

<details><summary>after</summary>
<p>

```
❯ git remote -v; zizmor --gh-token=$(gh auth token) .
origin  git@github.com:logyball/terraform-provider-grafana-adaptive-metrics.git (fetch)
origin  git@github.com:logyball/terraform-provider-grafana-adaptive-metrics.git (push)
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
No findings to report. Good job! (2 suppressed)
```

</p>
</details> 

# Note - Permissions

The permissions have changed based on zizmor's recommendations.  I don't believe that write permissions are required until the actual integration test, and they were applied to the entire `test.yml` workflow.  I've updated the permissions here, but am not _entirely_ sure that this is the exact right thing to do.

# Note - Version Pinning

I've simply version pinned the vault action to the latest commit SHA in `main`, as this action does not seem to use semver.