### PR TITLE
add auto-apply property to recommendations config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/resources/recommendations_config.md
+++ b/docs/resources/recommendations_config.md
@@ -23,4 +23,12 @@ resource "grafana-adaptive-metrics_recommendations_config" "singleton" {
 
 ### Optional
 
+- `auto_apply` (Attributes) WARNING: contact Grafana Cloud support before use. This feature is in private preview and may change without notice, including in ways that may break your configuration. Configurations related to auto-applying recommendations. (see [below for nested schema](#nestedatt--auto_apply))
 - `keep_labels` (List of String) The array of labels to keep; labels not in this array will be aggregated.
+
+<a id="nestedatt--auto_apply"></a>
+### Nested Schema for `auto_apply`
+
+Optional:
+
+- `enabled` (Boolean) WARNING: contact Grafana Cloud support before use. This feature is in private preview and may change without notice, including in ways that may break your configuration. Whether to automatically apply the generated recommendations in the default segment.

--- a/internal/model/recommendation_config.go
+++ b/internal/model/recommendation_config.go
@@ -7,7 +7,7 @@ import (
 
 type AggregationRecommendationConfiguration struct {
 	KeepLabels []string         `json:"keep_labels,omitempty" tfsdk:"keep_labels"`
-	AutoApply  *AutoApplyConfig `json:"auto_apply,omitempty"`
+	AutoApply  *AutoApplyConfig `json:"auto_apply,omitempty" tfsdk:"auto_apply"`
 }
 
 type AutoApplyConfig struct {

--- a/internal/model/recommendation_config.go
+++ b/internal/model/recommendation_config.go
@@ -1,24 +1,54 @@
 package model
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 type AggregationRecommendationConfiguration struct {
-	KeepLabels []string `json:"keep_labels,omitempty" tfsdk:"keep_labels"`
+	KeepLabels []string         `json:"keep_labels,omitempty" tfsdk:"keep_labels"`
+	AutoApply  *AutoApplyConfig `json:"auto_apply,omitempty"`
+}
+
+type AutoApplyConfig struct {
+	Enabled bool `json:"enabled" tfsdk:"enabled"`
 }
 
 func (c AggregationRecommendationConfiguration) ToTF() AggregationRecommendationConfigurationTF {
-	return AggregationRecommendationConfigurationTF{
+	cfg := AggregationRecommendationConfigurationTF{
 		KeepLabels: toTypesStringSlice(c.KeepLabels),
 	}
+
+	if c.AutoApply != nil {
+		cfg.AutoApply, _ = types.ObjectValue(map[string]attr.Type{"enabled": types.BoolType}, map[string]attr.Value{"enabled": types.BoolValue(e.AutoApply.Enabled)})
+	} else {
+		cfg.AutoApply = types.ObjectNull(map[string]attr.Type{"enabled": types.BoolType})
+	}
+
+	return cfg
 }
 
 type AggregationRecommendationConfigurationTF struct {
 	KeepLabels  []types.String `tfsdk:"keep_labels"`
+	AutoApply   types.Object   `tfsdk:"auto_apply"`
 	LastUpdated types.String   `tfsdk:"-"`
 }
 
 func (c AggregationRecommendationConfigurationTF) ToAPIReq() AggregationRecommendationConfiguration {
-	return AggregationRecommendationConfiguration{
+	cfg := AggregationRecommendationConfiguration{
 		KeepLabels: toStringSlice(c.KeepLabels),
 	}
+
+	if !c.AutoApply.IsNull() {
+		attrs := c.AutoApply.Attributes()
+		if enabled, ok := attrs["enabled"]; ok {
+			if boolVal, ok := enabled.(types.Bool); ok {
+				cfg.AutoApply = &AutoApplyConfig{
+					Enabled: boolVal.ValueBool(),
+				}
+			}
+		}
+	}
+
+	return cfg
 }

--- a/internal/model/recommendation_config.go
+++ b/internal/model/recommendation_config.go
@@ -20,7 +20,7 @@ func (c AggregationRecommendationConfiguration) ToTF() AggregationRecommendation
 	}
 
 	if c.AutoApply != nil {
-		cfg.AutoApply, _ = types.ObjectValue(map[string]attr.Type{"enabled": types.BoolType}, map[string]attr.Value{"enabled": types.BoolValue(e.AutoApply.Enabled)})
+		cfg.AutoApply, _ = types.ObjectValue(map[string]attr.Type{"enabled": types.BoolType}, map[string]attr.Value{"enabled": types.BoolValue(c.AutoApply.Enabled)})
 	} else {
 		cfg.AutoApply = types.ObjectNull(map[string]attr.Type{"enabled": types.BoolType})
 	}

--- a/internal/model/recommendation_config_test.go
+++ b/internal/model/recommendation_config_test.go
@@ -1,0 +1,146 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecommendationConfig_ToTF(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    AggregationRecommendationConfiguration
+		expected AggregationRecommendationConfigurationTF
+	}{
+		{
+			name: "basic recommendation config without auto_apply",
+			input: AggregationRecommendationConfiguration{
+				KeepLabels: []string{"namespace", "namespace2"},
+				AutoApply:  nil,
+			},
+			expected: AggregationRecommendationConfigurationTF{
+				KeepLabels: []types.String{types.StringValue("namespace"), types.StringValue("namespace2")},
+				AutoApply:  types.ObjectNull(map[string]attr.Type{"enabled": types.BoolType}),
+			},
+		},
+		{
+			name: "recommendation config with auto_apply enabled",
+			input: AggregationRecommendationConfiguration{
+				KeepLabels: []string{"namespace", "namespace2"},
+				AutoApply: &AutoApplyConfig{
+					Enabled: true,
+				},
+			},
+			expected: AggregationRecommendationConfigurationTF{
+				KeepLabels: []types.String{types.StringValue("namespace"), types.StringValue("namespace2")},
+				AutoApply: func() types.Object {
+					obj, _ := types.ObjectValue(
+						map[string]attr.Type{"enabled": types.BoolType},
+						map[string]attr.Value{"enabled": types.BoolValue(true)},
+					)
+					return obj
+				}(),
+			},
+		},
+		{
+			name: "recommendation config with auto_apply disabled",
+			input: AggregationRecommendationConfiguration{
+				KeepLabels: []string{"namespace", "namespace2"},
+				AutoApply: &AutoApplyConfig{
+					Enabled: false,
+				},
+			},
+			expected: AggregationRecommendationConfigurationTF{
+				KeepLabels: []types.String{types.StringValue("namespace"), types.StringValue("namespace2")},
+				AutoApply: func() types.Object {
+					obj, _ := types.ObjectValue(
+						map[string]attr.Type{"enabled": types.BoolType},
+						map[string]attr.Value{"enabled": types.BoolValue(false)},
+					)
+					return obj
+				}(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.input.ToTF()
+			assert.Equal(t, tt.expected.KeepLabels, result.KeepLabels)
+			assert.Equal(t, tt.expected.AutoApply, result.AutoApply)
+		})
+	}
+}
+
+func TestRecommendationConfigTF_ToAPIReq(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    AggregationRecommendationConfigurationTF
+		expected AggregationRecommendationConfiguration
+	}{
+		{
+			name: "basic recommendation config without auto_apply",
+			input: AggregationRecommendationConfigurationTF{
+				KeepLabels: []types.String{types.StringValue("namespace"), types.StringValue("namespace2")},
+				AutoApply:  types.ObjectNull(map[string]attr.Type{"enabled": types.BoolType}),
+			},
+			expected: AggregationRecommendationConfiguration{
+				KeepLabels: []string{"namespace", "namespace2"},
+				AutoApply:  nil,
+			},
+		},
+		{
+			name: "recommendation config with auto_apply enabled",
+			input: AggregationRecommendationConfigurationTF{
+				KeepLabels: []types.String{types.StringValue("namespace"), types.StringValue("namespace2")},
+				AutoApply: func() types.Object {
+					obj, _ := types.ObjectValue(
+						map[string]attr.Type{"enabled": types.BoolType},
+						map[string]attr.Value{"enabled": types.BoolValue(true)},
+					)
+					return obj
+				}(),
+			},
+			expected: AggregationRecommendationConfiguration{
+				KeepLabels: []string{"namespace", "namespace2"},
+				AutoApply: &AutoApplyConfig{
+					Enabled: true,
+				},
+			},
+		},
+		{
+			name: "recommendation config with auto_apply disabled",
+			input: AggregationRecommendationConfigurationTF{
+				KeepLabels: []types.String{types.StringValue("namespace"), types.StringValue("namespace2")},
+				AutoApply: func() types.Object {
+					obj, _ := types.ObjectValue(
+						map[string]attr.Type{"enabled": types.BoolType},
+						map[string]attr.Value{"enabled": types.BoolValue(false)},
+					)
+					return obj
+				}(),
+			},
+			expected: AggregationRecommendationConfiguration{
+				KeepLabels: []string{"namespace", "namespace2"},
+				AutoApply: &AutoApplyConfig{
+					Enabled: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.input.ToAPIReq()
+			assert.Equal(t, tt.expected.KeepLabels, result.KeepLabels)
+			if tt.expected.AutoApply == nil {
+				assert.Nil(t, result.AutoApply)
+			} else {
+				assert.NotNil(t, result.AutoApply)
+				assert.Equal(t, tt.expected.AutoApply.Enabled, result.AutoApply.Enabled)
+			}
+		})
+	}
+}

--- a/internal/model/segment.go
+++ b/internal/model/segment.go
@@ -13,10 +13,6 @@ type Segment struct {
 	AutoApply         *AutoApplyConfig `json:"auto_apply,omitempty"`
 }
 
-type AutoApplyConfig struct {
-	Enabled bool `json:"enabled" tfsdk:"enabled"`
-}
-
 func (e Segment) ToTF() SegmentTF {
 	segment := SegmentTF{
 		ID:                types.StringValue(e.ID),

--- a/internal/provider/recommendations_config_resource.go
+++ b/internal/provider/recommendations_config_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -58,6 +59,18 @@ func (r *recommendationsConfigResource) Schema(_ context.Context, _ resource.Sch
 				Computed:    true,
 				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 				Description: "The array of labels to keep; labels not in this array will be aggregated.",
+			},
+			"auto_apply": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: privatePreviewWarning + "Configurations related to auto-applying recommendations.",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
+						Description: privatePreviewWarning + "Whether to automatically apply the generated recommendations in the default segment.",
+					},
+				},
 			},
 		},
 	}

--- a/internal/provider/recommendations_config_resource_test.go
+++ b/internal/provider/recommendations_config_resource_test.go
@@ -37,6 +37,23 @@ resource "grafana-adaptive-metrics_recommendations_config" "test" {
 					resource.TestCheckResourceAttr("grafana-adaptive-metrics_recommendations_config.test", "keep_labels.1", "foobaz"),
 				),
 			},
+			// Update enabling auto_apply + Read.
+			{
+				Config: providerConfig + `
+resource "grafana-adaptive-metrics_recommendations_config" "test" {
+	keep_labels = ["foobar", "foobaz"]
+	auto_apply = {
+		enabled = true
+	}
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana-adaptive-metrics_recommendations_config.test", "keep_labels.#", "2"),
+					resource.TestCheckResourceAttr("grafana-adaptive-metrics_recommendations_config.test", "keep_labels.0", "foobar"),
+					resource.TestCheckResourceAttr("grafana-adaptive-metrics_recommendations_config.test", "keep_labels.1", "foobaz"),
+					resource.TestCheckResourceAttr("grafana-adaptive-metrics_recommendations_config.test", "auto_apply.enabled", "true"),
+				),
+			},
 			// Delete happens automatically.
 		},
 	})


### PR DESCRIPTION
Update the recommendations config object to add the new auto-apply configuration flag.

With the new tests I had to raise the test timeout to make them pass in the CI.