### PR TITLE
[docs] make auto-apply not private preview

### DIFF
--- a/docs/resources/recommendations_config.md
+++ b/docs/resources/recommendations_config.md
@@ -23,7 +23,7 @@ resource "grafana-adaptive-metrics_recommendations_config" "singleton" {
 
 ### Optional
 
-- `auto_apply` (Attributes) WARNING: contact Grafana Cloud support before use. This feature is in private preview and may change without notice, including in ways that may break your configuration. Configurations related to auto-applying recommendations. (see [below for nested schema](#nestedatt--auto_apply))
+- `auto_apply` (Attributes) Configurations related to auto-applying recommendations. (see [below for nested schema](#nestedatt--auto_apply))
 - `keep_labels` (List of String) The array of labels to keep; labels not in this array will be aggregated.
 
 <a id="nestedatt--auto_apply"></a>

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -30,7 +30,7 @@ resource "grafana-adaptive-metrics_segment" "s1" {
 
 ### Optional
 
-- `auto_apply` (Attributes) WARNING: contact Grafana Cloud support before use. This feature is in private preview and may change without notice, including in ways that may break your configuration. Configurations related to auto-applying recommendations. (see [below for nested schema](#nestedatt--auto_apply))
+- `auto_apply` (Attributes) Configurations related to auto-applying recommendations. (see [below for nested schema](#nestedatt--auto_apply))
 - `fallback_to_default` (Boolean) Whether to fallback to the default segment if the selector does not match any segments.
 - `policy_id` (String) WARNING: contact Grafana Cloud support before use. This feature is in private preview and may change without notice, including in ways that may break your configuration. ID of the policy applied to this segment.
 

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -43,4 +43,4 @@ resource "grafana-adaptive-metrics_segment" "s1" {
 
 Optional:
 
-- `enabled` (Boolean) WARNING: contact Grafana Cloud support before use. This feature is in private preview and may change without notice, including in ways that may break your configuration. Whether to automatically apply the generated recommendations in this segment.
+- `enabled` (Boolean) Whether to automatically apply the generated recommendations in this segment.

--- a/internal/provider/recommendations_config_resource.go
+++ b/internal/provider/recommendations_config_resource.go
@@ -62,7 +62,7 @@ func (r *recommendationsConfigResource) Schema(_ context.Context, _ resource.Sch
 			},
 			"auto_apply": schema.SingleNestedAttribute{
 				Optional:    true,
-				Description: privatePreviewWarning + "Configurations related to auto-applying recommendations.",
+				Description: "Configurations related to auto-applying recommendations.",
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
 						Optional:    true,

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -102,13 +102,13 @@ func (e *segmentResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"auto_apply": schema.SingleNestedAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: privatePreviewWarning + "Configurations related to auto-applying recommendations.",
+				Description: "Configurations related to auto-applying recommendations.",
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
 						Default:     booldefault.StaticBool(false),
-						Description: privatePreviewWarning + "Whether to automatically apply the generated recommendations in this segment.",
+						Description: "Whether to automatically apply the generated recommendations in this segment.",
 					},
 				},
 			},


### PR DESCRIPTION
Currently the auto-apply feature is still marked as "private preview" even though it's already generally available.

[Context on Slack](https://raintank-corp.slack.com/archives/C07FBAEPENT/p1769203926823259)