### PR TITLE
mark segment auto-apply property as "computed"

### DIFF
--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -100,6 +101,7 @@ func (e *segmentResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"auto_apply": schema.SingleNestedAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: privatePreviewWarning + "Configurations related to auto-applying recommendations.",
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{


### PR DESCRIPTION
With the switch to the SQL backed segments repo in the aggregations-api, the segment property `auto_apply` is now always defined. If the request to create a segment did not define it, the API will return it as "disabled". This updates the Terraform provider to handle this by marking the property as "computed".