### PR TITLE
[adaptive-metrics.terraform-provider] don't set default policy id in provider

### DIFF
--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -18,35 +18,10 @@ type segmentResource struct {
 	client *client.Client
 }
 
-func (e *segmentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	var config model.SegmentTF
-	var state model.SegmentTF
-	var plan model.SegmentTF
-
-	// Config = what user wrote in .tf
-	req.Config.Get(ctx, &config)
-	// State = what Terraform knew before
-	req.State.Get(ctx, &state)
-	// Plan = what Terraform has planned so far
-	req.Plan.Get(ctx, &plan)
-
-	// if policy_id was removed on already created resource it's not a default policy, override a plan to set policy_id to default policy ID.
-	if !state.ID.IsNull() && config.PolicyID.IsNull() && state.PolicyID.String() != state.ID.String() {
-		resp.Diagnostics.AddWarning(
-			fmt.Sprintf("The segment %q will be reset to default policy.", config.Name.ValueString()),
-			"User removed policy_id field, setting policy_id to default policy ID.",
-		)
-		plan.PolicyID = state.ID
-	}
-
-	resp.Plan.Set(ctx, &plan)
-}
-
 var (
 	_ resource.Resource                = &segmentResource{}
 	_ resource.ResourceWithConfigure   = &segmentResource{}
 	_ resource.ResourceWithImportState = &segmentResource{}
-	_ resource.ResourceWithModifyPlan  = &segmentResource{}
 )
 
 func newSegmentResource() resource.Resource {


### PR DESCRIPTION
We don't want to set the default policy id in the Terraform provider, because:

* Not all users have the policy id feature enabled yet, in all these cases Terraform is going to error out because it will post a segment definition with policy id defined, but the API will not return that property, which confuses Terraform
* If we want to set the policy id to the segment id by default everywhere, we should do this in the API to make sure that it applies to all users in the same way

[Context on Slack](https://raintank-corp.slack.com/archives/C08UE9ZL1RQ/p1769466879949069)